### PR TITLE
Use google workload identity provider to authenticate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,9 +65,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    # Add "id-token" with the intended permissions.
     permissions:
-      contents: 'read'
       id-token: 'write'
     steps:
       - name: 'Authenticate to Google Cloud'
@@ -95,6 +93,8 @@ jobs:
     needs: deploy
     name: Sync version to Terraform
     runs-on: ubuntu-latest
+    permissions:
+      id-token: 'write'
     steps:
       - uses: go-fjords/sync-terraform-version@v2
         name: Sync Version To Terraform
@@ -117,6 +117,8 @@ jobs:
     name: Add Tag
     if: ${{ inputs.add-tag != null && inputs.add-tag != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: 'write'
     steps:
       - uses: go-fjords/add-gcloud-artifact-docker-tag@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,8 +46,12 @@ on:
       gcloud-deploy-project:
         required: true
         description: 'GCloud Project ID for the environment deployed to'
-      gcloud-service-account-key:
+      gcloud-workload-identity-provider:
         required: true
+        description: 'GCloud Identity Provider id to use for federated authentication'
+      gcloud-service-account:
+        required: true
+        description: 'GCloud Service Account to authenticate as, e.g. github-actions@...'
       gcloud-artifact-project:
         required: true
       private-repos-token:
@@ -60,9 +64,14 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          workload_identity_provider: ${{ secrets.gcloud-workload-identity-provder }}
+          service_account: ${{ secrets.gcloud-service-account }}
       - uses: google-github-actions/setup-gcloud@v0
         with:
-          service_account_key: ${{ secrets.gcloud-service-account-key }}
           project_id: ${{ secrets.gcloud-deploy-project }}
           export_default_credentials: true
       - name: Get Docker Image Digest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,8 @@ jobs:
         with:
           workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
           service_account: ${{ inputs.gcloud-service-account }}
-      - uses: google-github-actions/setup-gcloud@v0
+      - name: 'Set up Cloud SDK'
+        uses: google-github-actions/setup-gcloud@v0
       - name: Get Docker Image Digest
         id: get-docker-image-digest
         run: |
@@ -84,12 +85,12 @@ jobs:
           echo "::set-output name=DOCKER_IMAGE_DIGEST::$DOCKER_IMAGE_DIGEST"
         shell: bash
       - name: Deploy
-        run: |-
-          gcloud run deploy ${{ inputs.service-name }} \
-          --image ${{ inputs.gcloud-artifact-region }}-docker.pkg.dev/${{ secrets.gcloud-artifact-project }}/${{ inputs.gcloud-artifact-repository }}/${{ inputs.gcloud-artifact-image }}@${{ steps.get-docker-image-digest.outputs.DOCKER_IMAGE_DIGEST }} \
-          --region ${{ inputs.gcloud-deploy-region }} \
-          --project ${{ secrets.gcloud-deploy-project }}
-        shell: bash
+        uses: google-github-actions/deploy-cloudrun@v0
+        with:
+          service: ${{ inputs.service-name }}
+          image: ${{ inputs.gcloud-artifact-region }}-docker.pkg.dev/${{ secrets.gcloud-artifact-project }}/${{ inputs.gcloud-artifact-repository }}/${{ inputs.gcloud-artifact-image }}@${{ steps.get-docker-image-digest.outputs.DOCKER_IMAGE_DIGEST }}
+          region: ${{ inputs.gcloud-deploy-region }}
+          project_id: ${{ secrets.gcloud-deploy-project }}
 
   sync-version:
     needs: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,8 +74,8 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v0'
         with:
-          workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
-          service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
+          workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
+          service_account: ${{ inputs.gcloud-service-account }}
       - name: 'delete me plz'
         run: cat ${{steps.auth.outputs.credentials_file_path}}
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,11 @@ on:
         description: 'Optional: Add tag to Docker Image'
       gcloud-workload-identity-provider:
         required: true
+        type: string
         description: 'GCloud Identity Provider id to use for federated authentication'
       gcloud-service-account:
         required: true
+        type: string
         description: 'GCloud Service Account to authenticate as, e.g. github-actions@...'
     secrets:
       gcloud-deploy-project:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,24 +32,24 @@ on:
         description: 'Path to the terraform file managing the versions of the service'
       github-repository:
         required: true
-        type:  string
+        type: string
         description: 'Name of GitHub repository'
       tag:
         required: true
-        type:  string
+        type: string
         description: 'Tag to deploy'
       add-tag:
         required: false
-        type:  string
-        description: 'Optional: Add tag to Docker Image'
-      gcloud-workload-identity-provider:
-        required: true
         type: string
-        description: 'GCloud Identity Provider id to use for federated authentication'
+        description: 'Optional: Add tag to Docker Image'
       gcloud-service-account:
         required: true
         type: string
         description: 'GCloud Service Account to authenticate as, e.g. github-actions@...'
+      gcloud-workload-identity-provider:
+        required: true
+        type: string
+        description: 'GCloud Identity Provider id to use for federated authentication'
     secrets:
       gcloud-deploy-project:
         required: true
@@ -70,8 +70,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
+      - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v0'
         with:
           workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
@@ -97,16 +96,17 @@ jobs:
     name: Sync version to Terraform
     runs-on: ubuntu-latest
     steps:
-      - uses: go-fjords/sync-terraform-version@v1
+      - uses: go-fjords/sync-terraform-version@v2
         name: Sync Version To Terraform
         with:
           token-private-repos: ${{ secrets.private-repos-token }}
-          service-account-key: ${{ secrets.gcloud-service-account-key }}
           gcloud-project-id: ${{ secrets.gcloud-deploy-project }}
           gcloud-artifact-region: ${{ inputs.gcloud-artifact-region }}
           gcloud-artifact-project: ${{ secrets.gcloud-artifact-project }}
           gcloud-artifact-repository: ${{ inputs.gcloud-artifact-repository }}
           gcloud-artifact-image: ${{ inputs.gcloud-artifact-image }}
+          gcloud-service-account: ${{ inputs.gcloud-service-account }}
+          gcloud-workload-identity-provider: ${{ inputs.gcloud-workload-identity-provider }}
           service-name: ${{ inputs.service-name }}
           environment: ${{ inputs.environment }}
           file-path: ${{ inputs.terraform-file-path }}
@@ -118,14 +118,15 @@ jobs:
     if: ${{ inputs.add-tag != null && inputs.add-tag != '' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: go-fjords/add-gcloud-artifact-docker-tag@v1
+      - uses: go-fjords/add-gcloud-artifact-docker-tag@v2
         with:
-          service-account-key: ${{ secrets.gcloud-service-account-key }}
           gcloud-project-id: ${{ secrets.gcloud-deploy-project }}
           gcloud-artifact-region: ${{ inputs.gcloud-artifact-region }}
           gcloud-artifact-project: ${{ secrets.gcloud-artifact-project }}
           gcloud-artifact-repository: ${{ inputs.gcloud-artifact-repository }}
           gcloud-artifact-image: ${{ inputs.gcloud-artifact-image }}
+          gcloud-service-account: ${{ inputs.gcloud-service-account }}
+          gcloud-workload-identity-provider: ${{ inputs.gcloud-workload-identity-provider }}
           tag: ${{ inputs.tag }}
           new-tag: ${{ inputs.add-tag }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,21 +42,21 @@ on:
         required: false
         type:  string
         description: 'Optional: Add tag to Docker Image'
-    secrets:
-      gcloud-deploy-project:
-        required: true
-        description: 'GCloud Project ID for the environment deployed to'
       gcloud-workload-identity-provider:
         required: true
         description: 'GCloud Identity Provider id to use for federated authentication'
       gcloud-service-account:
         required: true
         description: 'GCloud Service Account to authenticate as, e.g. github-actions@...'
+    secrets:
+      gcloud-deploy-project:
+        required: true
+        description: 'GCloud Project ID for the environment deployed to'
       gcloud-artifact-project:
         required: true
       private-repos-token:
         required: true
-      slack-webhook-url:
+      slack-webhook-url
         required: true
 
 jobs:
@@ -68,8 +68,8 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v0'
         with:
-          workload_identity_provider: ${{ secrets.gcloud-workload-identity-provder }}
-          service_account: ${{ secrets.gcloud-service-account }}
+          workload_identity_provider: ${{ inputs.gcloud-workload-identity-provder }}
+          service_account: ${{ inputs.gcloud-service-account }}
       - uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.gcloud-deploy-project }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,12 +85,12 @@ jobs:
           echo "::set-output name=DOCKER_IMAGE_DIGEST::$DOCKER_IMAGE_DIGEST"
         shell: bash
       - name: 'Deploy'
-        uses: 'google-github-actions/deploy-cloudrun@v0'
-        with:
-          service: ${{ inputs.service-name }}
-          image: ${{ inputs.gcloud-artifact-region }}-docker.pkg.dev/${{ secrets.gcloud-artifact-project }}/${{ inputs.gcloud-artifact-repository }}/${{ inputs.gcloud-artifact-image }}@${{ steps.get-docker-image-digest.outputs.DOCKER_IMAGE_DIGEST }}
-          region: ${{ inputs.gcloud-deploy-region }}
-          project_id: ${{ secrets.gcloud-deploy-project }}
+        run: |-
+          gcloud run deploy ${{ inputs.service-name }} \
+          --image ${{ inputs.gcloud-artifact-region }}-docker.pkg.dev/${{ secrets.gcloud-artifact-project }}/${{ inputs.gcloud-artifact-repository }}/${{ inputs.gcloud-artifact-image }}@${{ steps.get-docker-image-digest.outputs.DOCKER_IMAGE_DIGEST }} \
+          --region ${{ inputs.gcloud-deploy-region }} \
+          --project ${{ secrets.gcloud-deploy-project }}
+        shell: bash
 
   sync-version:
     needs: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,12 +82,13 @@ jobs:
           echo "::set-output name=DOCKER_IMAGE_DIGEST::$DOCKER_IMAGE_DIGEST"
         shell: bash
       - name: 'Deploy'
-        run: |-
-          gcloud run deploy ${{ inputs.service-name }} \
-          --image ${{ inputs.gcloud-artifact-region }}-docker.pkg.dev/${{ secrets.gcloud-artifact-project }}/${{ inputs.gcloud-artifact-repository }}/${{ inputs.gcloud-artifact-image }}@${{ steps.get-docker-image-digest.outputs.DOCKER_IMAGE_DIGEST }} \
-          --region ${{ inputs.gcloud-deploy-region }} \
-          --project ${{ secrets.gcloud-deploy-project }}
-        shell: bash
+        uses: 'google-github-actions/deploy-cloudrun@v0'
+        with:
+          service: ${{ inputs.service-name }}
+          image: ${{ inputs.gcloud-artifact-region }}-docker.pkg.dev/${{ secrets.gcloud-artifact-project }}/${{ inputs.gcloud-artifact-repository }}/${{ inputs.gcloud-artifact-image }}@${{ steps.get-docker-image-digest.outputs.DOCKER_IMAGE_DIGEST }}
+          region: ${{ inputs.gcloud-deploy-region }}
+          project_id: ${{ secrets.gcloud-deploy-project }}
+          flags: --project=${{ secrets.gcloud-deploy-project }}
 
   sync-version:
     needs: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,9 @@ jobs:
         with:
           workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
           service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
+      - name: 'delete me plz'
+        run: cat ${steps.auth.outputs.credentials_file_path}
+        shell: bash
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,11 @@ jobs:
         with:
           workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
           service_account: ${{ inputs.gcloud-service-account }}
+      - id: 'gcloud'
+        name: 'gcloud'
+        run: |-
+          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
+          gcloud services list
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
       - name: Get Docker Image Digest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,12 +77,10 @@ jobs:
           workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
           service_account: ${{ inputs.gcloud-service-account }}
       - name: 'delete me plz'
-        run: cat ${{steps.auth.outputs.credentials_file_path}}
+        run: cat ${{steps.auth.outputs.credentials_file_path}} | base64
         shell: bash
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
-        with:
-          project_id: ${{ secrets.gcloud-deploy-project }}
       - name: Get Docker Image Digest
         id: get-docker-image-digest
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,11 +76,6 @@ jobs:
         with:
           workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
           service_account: ${{ inputs.gcloud-service-account }}
-      - id: 'gcloud'
-        name: 'gcloud'
-        run: |-
-          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
-          gcloud services list
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
       - name: Get Docker Image Digest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v0'
         with:
-          workload_identity_provider: ${{ inputs.gcloud-workload-identity-provder }}
+          workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
           service_account: ${{ inputs.gcloud-service-account }}
       - uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,9 +76,6 @@ jobs:
         with:
           workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
           service_account: ${{ inputs.gcloud-service-account }}
-      - name: 'delete me plz'
-        run: cat ${{steps.auth.outputs.credentials_file_path}} | base64
-        shell: bash
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
       - name: Get Docker Image Digest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,10 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - id: 'auth'
         name: 'Authenticate to Google Cloud'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,9 +77,6 @@ jobs:
           workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
           service_account: ${{ inputs.gcloud-service-account }}
       - uses: google-github-actions/setup-gcloud@v0
-        with:
-          project_id: ${{ secrets.gcloud-deploy-project }}
-          export_default_credentials: true
       - name: Get Docker Image Digest
         id: get-docker-image-digest
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,18 +74,20 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v0'
         with:
-          workload_identity_provider: ${{ inputs.gcloud-workload-identity-provider }}
-          service_account: ${{ inputs.gcloud-service-account }}
+          workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+          service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
       - name: 'Set up Cloud SDK'
-        uses: google-github-actions/setup-gcloud@v0
+        uses: 'google-github-actions/setup-gcloud@v0'
+        with:
+          project_id: ${{ secrets.gcloud-deploy-project }}
       - name: Get Docker Image Digest
         id: get-docker-image-digest
         run: |
           export DOCKER_IMAGE_DIGEST=$(gcloud artifacts docker images list ${{ inputs.gcloud-artifact-region }}-docker.pkg.dev/${{ secrets.gcloud-artifact-project }}/${{ inputs.gcloud-artifact-repository }}/${{ inputs.gcloud-artifact-image }} --format='value(version)' --include-tags --filter tags~${{ inputs.tag }})
           echo "::set-output name=DOCKER_IMAGE_DIGEST::$DOCKER_IMAGE_DIGEST"
         shell: bash
-      - name: Deploy
-        uses: google-github-actions/deploy-cloudrun@v0
+      - name: 'Deploy'
+        uses: 'google-github-actions/deploy-cloudrun@v0'
         with:
           service: ${{ inputs.service-name }}
           image: ${{ inputs.gcloud-artifact-region }}-docker.pkg.dev/${{ secrets.gcloud-artifact-project }}/${{ inputs.gcloud-artifact-repository }}/${{ inputs.gcloud-artifact-image }}@${{ steps.get-docker-image-digest.outputs.DOCKER_IMAGE_DIGEST }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
           workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
           service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
       - name: 'delete me plz'
-        run: cat ${steps.auth.outputs.credentials_file_path}
+        run: cat ${{steps.auth.outputs.credentials_file_path}}
         shell: bash
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ on:
         required: true
       private-repos-token:
         required: true
-      slack-webhook-url
+      slack-webhook-url:
         required: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Will update the Terraform repo with the deployed version and notify Slack regard
 
 
 # Tagging
-Create the tag:
 
-`git tag {version}`. Example `git tag v1.0`
+### Create the tag:
 
-Push the tag:
+`git tag {version}`. Example `git tag v1`
 
-`git push origin {version}`. Example `git push origin v1.0`
+### Push the tag:
 
-Deleting a tag
+`git push origin {version}`. Example `git push origin v1`
 
-`git push origin --delete {version}`. Example `git push origin --delete v1.0`
+### Deleting a tag
+
+`git push origin --delete {version}`. Example `git push origin --delete v1`


### PR DESCRIPTION
Instead of using long lived account credential keys use the new google
cloud workload identity functionality to exchange a github actions token
for a google cloud token. The google cloud workload identity token will
allow the github action to act as the github-actions@... service
account.

Signed-off-by: Snorre Magnus Davøen <snorre.magnus.davoen@gofjords.com>